### PR TITLE
Implement light theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,11 +116,16 @@
                 </ul>
             </nav>
             
-            <button class="menu-toggle" aria-label="Toggle menu">
-                <span></span>
-                <span></span>
-                <span></span>
-            </button>
+            <div class="header-actions">
+                <button class="theme-toggle" aria-label="Toggle theme">
+                    <i class="fa fa-moon"></i>
+                </button>
+                <button class="menu-toggle" aria-label="Toggle menu">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+            </div>
         </div>
     </header>
 

--- a/script.js
+++ b/script.js
@@ -8,6 +8,33 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Set current year for footer
     document.getElementById('current-year').textContent = new Date().getFullYear();
+
+    // ==========================================
+    // Theme toggle
+    // ==========================================
+    const themeToggleBtn = document.querySelector('.theme-toggle');
+
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (savedTheme === 'light' || (!savedTheme && !prefersDark)) {
+        document.body.classList.add('light-theme');
+    }
+
+    function updateThemeIcon() {
+        if (!themeToggleBtn) return;
+        const isLight = document.body.classList.contains('light-theme');
+        themeToggleBtn.innerHTML = `<i class="fa ${isLight ? 'fa-sun' : 'fa-moon'}"></i>`;
+    }
+    updateThemeIcon();
+
+    if (themeToggleBtn) {
+        themeToggleBtn.addEventListener('click', () => {
+            document.body.classList.toggle('light-theme');
+            const isLight = document.body.classList.contains('light-theme');
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+            updateThemeIcon();
+        });
+    }
     
     // ==========================================
     // Logo click - back to top or navigate to home

--- a/styles.css
+++ b/styles.css
@@ -367,6 +367,31 @@ body.cursor-hover .cursor-outline {
   align-items: center;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: var(--light);
+  border: 2px solid var(--light);
+  border-radius: var(--radius-pill);
+  background: none;
+  cursor: pointer;
+  transition: background-color var(--transition-medium), color var(--transition-medium);
+}
+
+.theme-toggle:hover {
+  background-color: var(--primary);
+  color: var(--darker);
+}
+
 .logo {
   position: relative;
   z-index: var(--z-medium);
@@ -715,6 +740,11 @@ body.cursor-hover .cursor-outline {
   
   .menu-toggle {
     display: flex;
+  }
+
+  .theme-toggle {
+    width: 28px;
+    height: 28px;
   }
   
   .hero-content {
@@ -1764,5 +1794,22 @@ body.cursor-hover .cursor-outline {
 ::selection {
   background-color: rgba(144, 96, 255, 0.2);
   color: var(--light);
+}
+
+/* ==========================================
+   Light Theme Overrides
+   ========================================== */
+body.light-theme {
+  --dark: #f4f4f9;
+  --darker: #ffffff;
+  --light: #0f0f17;
+  --gray: #444444;
+  --gray-dark: #666666;
+  background-color: var(--darker);
+  color: var(--light);
+}
+
+body.light-theme .header.scrolled {
+  background-color: rgba(255, 255, 255, 0.95);
 }
 


### PR DESCRIPTION
## Summary
- add a theme toggle button to the header
- style theme button and define light theme overrides
- implement JavaScript logic for toggling and storing theme preference

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f631226e0832c81ada19151ea9617